### PR TITLE
Remove id and ts from event meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ API
 
 `uv.emit(type, [data])`
 
-Emits an event with the __type__ and __data__ specified. The __data__ should conform to the schema for the event __type__ emitted. All events that are emitted are given a `meta` property with a client timestamp `clientTs`, a client ID `clientId`, and the event type, `type`.
+Emits an event with the __type__ and __data__ specified. The __data__ should conform to the schema for the event __type__ emitted. All events that are emitted are given a `meta` property with the event `type`.
 
 ```javascript
 uv.emit('ec.ProductView', {
@@ -46,8 +46,6 @@ The emitted event will have meta attached.
 ```json
 {
   "meta": {
-    "clientTs": 1423666795563,
-    "clientId": "43d2b1b1-d2b6-7f16-d96c-175efa35",
     "type": "ec.ProductView"
   },
   "product": {

--- a/test/test-uv-api.js
+++ b/test/test-uv-api.js
@@ -20,7 +20,7 @@ describe('Universal Variable API', function () {
   })
 
   describe('emit', function () {
-    var t1, t2, eventsLength, data
+    var eventsLength, data
 
     beforeEach(function () {
       data = {
@@ -29,7 +29,6 @@ describe('Universal Variable API', function () {
       uv.on('ec:transaction', function () {
         eventsLength = uv.events.length
       })
-      t1 = new Date()
       uv.emit('search')
       uv.emit('ec:product.view')
       uv.emit('search')
@@ -38,15 +37,14 @@ describe('Universal Variable API', function () {
       })
       uv.emit('ec:basket.add')
       uv.emit('ec:transaction', data)
-      t2 = new Date()
     })
 
     it('should add each event to the events array', function () {
       expect(uv.events.length).to.be(6)
     })
-    it('should create a meta property with ts, id and type properties', function () {
+    it('should create a meta property with type property', function () {
       forEach(uv.events, function (event) {
-        expect(event.meta).to.only.have.keys('ts', 'id', 'type')
+        expect(event.meta).to.only.have.keys('type')
       })
     })
     it('should keep data associated with the event', function () {
@@ -64,22 +62,6 @@ describe('Universal Variable API', function () {
         'ec:basket.add',
         'ec:transaction'
       ])
-    })
-    it('should generate a unique ID', function () {
-      var ids = []
-      forEach(uv.events, function (event) {
-        expect(event.meta.id).to.be.a('string')
-        forEach(ids, function (id) {
-          expect(event.meta.id).to.not.be(id)
-        })
-        ids.push(event.meta.id)
-      })
-    })
-    it('should generate a timestamp', function () {
-      for (var i = 0; i < 6; i++) {
-        expect(uv.events[i].meta.ts >= t1.getTime()).to.be(true)
-        expect(uv.events[i].meta.ts <= t2.getTime()).to.be(true)
-      }
     })
     it('should add events to events array before calling listeners', function () {
       expect(eventsLength).to.be(6)

--- a/uv-api.js
+++ b/uv-api.js
@@ -22,8 +22,6 @@
   uv.emit = function emit (type, data) {
     data = clone(data || {})
     data.meta = {
-      id: guid(),
-      ts: (new Date()).getTime(),
       type: type
     }
     uv.events.push(data)
@@ -108,23 +106,6 @@
     for (var i = 0; i < list.length; i++) {
       iterator(list[i], i)
     }
-  }
-
-  /**
-   * Returns a random 4 digit hexidecimal number.
-   */
-  function s4 () {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1)
-  }
-
-  /**
-   * Returns a guid.
-   */
-  function guid () {
-    return [s4(), s4(), '-', s4(), '-', s4(), '-', s4(), '-', s4(), s4()]
-      .join('')
   }
 
   /**


### PR DESCRIPTION
These will instead come from Jolt, simplifying the UV API a little.
