### PR TITLE
on and once accept regex's

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ The emitted event will have meta attached.
 
 `uv.on(type, handler, [context])`
 
-Attaches an event __handler__ to be called when a certain event __type__ is emitted. The __handler__ will be passed the event data and will be bound to the __context__ object, if one is passed. Returns a subscription object which can detatch the handler using the dispose method. If an event __type__ `*` is passed, the handler will execute on all events.
+Attaches an event __handler__ to be called when a certain event __type__ is emitted. The __handler__ will be passed the event data and will be bound to the __context__ object, if one is passed. Returns a subscription object which can detatch the handler using the dispose method. If a regex is passed, the handler will execute on events that match the regex.
 
 ```javascript
 uv.on('ec.Product.View', function (data) {
   console.log(data)
 })
 // => logs data when an `ec.Product.View` event is emitted
-var sub = uv.on('*', function (data) {
+var sub = uv.on(/.*/, function (data) {
   console.log(data)
 })
 // => logs data for all events
@@ -90,7 +90,7 @@ sub.dispose()
 
 `uv.once(type, handler, [context])`
 
-Attaches an event __handler__ that will be called once, only on the next event emitted that matches the __type__ specified. The __handler__ will be passed the event data and will be bound to the context object, if one is passed. Returns a subscription object which can detatch the __handler__ using the dispose method. If an event __type__ `*` is passed, the __handler__ will execute on the next event regardless of type.
+Attaches an event __handler__ that will be called once, only on the next event emitted that matches the __type__ specified. The __handler__ will be passed the event data and will be bound to the context object, if one is passed. Returns a subscription object which can detatch the __handler__ using the dispose method. If a regex is passed, the handler will execute on the next event to match the regex.
 
 
 ```javascript

--- a/test/test-uv-api.js
+++ b/test/test-uv-api.js
@@ -99,7 +99,7 @@ describe('Universal Variable API', function () {
   describe('on listeners', function () {
     var sub, searchEvents, allEvents, productEvents,
       noneEvents, transactionEvents, errors, errorMemo,
-      allContext, stack
+      allContext, stack, regexEvents
 
     beforeEach(function () {
       errors = []
@@ -108,6 +108,7 @@ describe('Universal Variable API', function () {
       productEvents = []
       noneEvents = []
       transactionEvents = []
+      regexEvents = []
       stack = {}
       if (console && console.error) {
         errorMemo = console.error
@@ -126,7 +127,7 @@ describe('Universal Variable API', function () {
       uv.on('ec:product.view', function () {
         productEvents.push(arguments)
       })
-      uv.on('*', function () {
+      uv.on(/.*/, function () {
         allEvents.push(arguments)
         allContext = this
       }, { hi: 'dude' })
@@ -135,6 +136,9 @@ describe('Universal Variable API', function () {
       })
       sub = uv.on('ec:transaction', function () {
         transactionEvents.push(arguments)
+      })
+      uv.on(/[^.]*\.View/, function () {
+        regexEvents.push(arguments)
       })
       uv.emit('search', {
         resultCount: 10
@@ -152,6 +156,7 @@ describe('Universal Variable API', function () {
       uv.emit('ec:transaction', {
         orderId: 'oh-so-not-orderlicious'
       })
+      uv.emit('ec.View')
     })
 
     afterEach(function () {
@@ -175,7 +180,7 @@ describe('Universal Variable API', function () {
       expect(noneEvents.length).to.be(0)
     })
     it('should listen to all events given a wildcard type', function () {
-      expect(allEvents.length).to.be(5)
+      expect(allEvents.length).to.be(6)
     })
     it('should be called if another listener throws an error', function () {
       expect(productEvents.length).to.be(1)
@@ -191,6 +196,9 @@ describe('Universal Variable API', function () {
     })
     it('should not throw an error if dispose is called twice', function () {
       expect(sub.dispose).to.not.throwException()
+    })
+    it('should listen to events given a regex', function () {
+      expect(regexEvents.length).to.be(1)
     })
   })
 

--- a/uv-api.js
+++ b/uv-api.js
@@ -53,7 +53,9 @@ function createUv () {
   function callHandlers (event) {
     uv.events.push(event)
     forEach(uv.listeners, function (listener) {
-      if (listener.type === event.meta.type || listener.type === '*') {
+      var matches = typeof listener.type === 'string'
+        ? listener.type === event.meta.type : listener.type.test(event.meta.type)
+      if (matches) {
         try {
           listener.callback.call(listener.context, event)
         } catch (e) {
@@ -72,10 +74,11 @@ function createUv () {
   /**
    * Attaches an event handler to listen to the type of event specified.
    *
-   * @param   {String}   type         The type of event.
-   * @param   {Function} callback     The callback called when the event occurs.
-   * @param   {Object}   context      The context that will be applied to the callback (optional).
-   * @returns {Object}   subscription A subscription object that returns a dispose method.
+   * @param   {String|Regex} type         The type of event.
+   * @param   {Function}     callback     The callback called when the event occurs.
+   * @param   {Object}       context      The context that will be applied to the
+   *                                      callback (optional).
+   * @returns {Object}                    A subscription object that returns a dispose method.
    */
   function on (type, callback, context) {
     var ref = {}
@@ -103,11 +106,11 @@ function createUv () {
    * Attaches an event handler to listen to the type of event specified.
    * The handle will only be executed once.
    *
-   * @param   {String}   type         The type of event.
-   * @param   {Function} callback     The callback called when the event occurs.
-   * @param   {Object}   context      The context that will be applied
+   * @param   {String|Regex} type     The type of event.
+   * @param   {Function}     callback The callback called when the event occurs.
+   * @param   {Object}       context  The context that will be applied
    *                                  to the callback (optional).
-   * @returns {Object}   subscription A subscription object which can off the
+   * @returns {Object}                A subscription object which can off the
    *                                  handler using the dispose method.
    */
   function once (type, callback, context) {


### PR DESCRIPTION
- Use a regex to test the type of event that is emitted
- Remove the wildcard `*` in favour of `/.*/` which is more explicit
