### PR TITLE
Adding workaround for browser bugs.

### DIFF
--- a/uv-api.js
+++ b/uv-api.js
@@ -6,7 +6,7 @@ var modulePresent = false;
 try {
   if (typeof module === 'object' && module.exports) {
     module.exports = createUv
-    modulePresent = true;
+    modulePresent = true
   }
 } catch (ex) {
   // workaround: just catch in case browser complains for unset module prop.


### PR DESCRIPTION
Its problematic as it is actually a valid code, however browsers are buggy and i have numerous reports for the exception occurring while loading script. I am quite sure it is not only coming with opentag but with wherever the uv-api is loaded.

Wrapping module variable check is required, feel free to adjust it to whichever format you prefer (ill pull it too).

@roberttod: Opentag will use immediately the fix but it will be good if you adjust it and merge to master asap.

I think you can put the uv object declaration separately and module independent, maybe detecting global object (pick global scope) - literally removing the modulePresent check ;-)

```
try {
  if (typeof module === 'object' && module.exports) {
    module.exports = createUv
  }
} catch (ex) {
}
```
