### PR TITLE
Do not overwrite window.uv if it exists

### DIFF
--- a/uv-api.js
+++ b/uv-api.js
@@ -4,7 +4,7 @@
    */
   if (typeof module === 'object' && module.exports) {
     module.exports = createUv
-  } else if (window) {
+  } else if (window && window.uv === undefined) {
     window.uv = createUv()
   }
 


### PR DESCRIPTION
Moving this logic directly into the API in case people include it twice for whatever reason.